### PR TITLE
fix: enable multi-user chat with unique client IDs and message styling

### DIFF
--- a/app/api/route.js
+++ b/app/api/route.js
@@ -1,16 +1,11 @@
-import crypto from 'crypto';
 import Ably from 'ably';
 
-// ensure Vercel doesn't cache the result of this route,
-// as otherwise the token request data will eventually become outdated
-// and we won't be able to authenticate on client side
 export const revalidate = 0;
 
 export async function GET(request) {
+  const clientId = request.nextUrl.searchParams.get('clientId') || 'NO_CLIENT_ID_PROVIDED';
   const client = new Ably.Rest(process.env.ABLY_API_KEY);
-  const tokenRequestData = await client.auth.createTokenRequest({
-    clientId: crypto.randomUUID(),
-  });
+  const tokenRequestData = await client.auth.createTokenRequest({ clientId });
   console.log(`Request: ${JSON.stringify(tokenRequestData)}`);
   return Response.json(tokenRequestData);
 }

--- a/app/api/route.js
+++ b/app/api/route.js
@@ -11,7 +11,7 @@ export async function GET(request) {
 
   const now = Math.floor(Date.now() / 1000);
   const claims = {
-    'x-ably-capability': JSON.stringify({ '*': ['*'] }),
+    'x-ably-capability': JSON.stringify({ 'chat-demo:*': ['*'] }),
     'x-ably-clientId': clientId,
     iat: now,
     exp: now + 3600,

--- a/app/api/route.js
+++ b/app/api/route.js
@@ -1,4 +1,4 @@
-import Ably from 'ably';
+import jwt from 'jsonwebtoken';
 
 // ensure Vercel doesn't cache the result of this route,
 // as otherwise the token request data will eventually become outdated
@@ -7,8 +7,20 @@ export const revalidate = 0;
 
 export async function GET(request) {
   const clientId = request.nextUrl.searchParams.get('clientId') || 'NO_CLIENT_ID_PROVIDED';
-  const client = new Ably.Rest(process.env.ABLY_API_KEY);
-  const tokenRequestData = await client.auth.createTokenRequest({ clientId });
-  console.log(`Request: ${JSON.stringify(tokenRequestData)}`);
-  return Response.json(tokenRequestData);
+  const [keyName, keySecret] = process.env.ABLY_API_KEY.split(':');
+
+  const now = Math.floor(Date.now() / 1000);
+  const claims = {
+    'x-ably-capability': JSON.stringify({ '*': ['*'] }),
+    'x-ably-clientId': clientId,
+    iat: now,
+    exp: now + 3600,
+  };
+
+  const token = jwt.sign(claims, keySecret, { algorithm: 'HS256', keyid: keyName });
+
+  return new Response(token, {
+    status: 200,
+    headers: { 'Content-Type': 'application/jwt' },
+  });
 }

--- a/app/api/route.js
+++ b/app/api/route.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import Ably from 'ably';
 
 // ensure Vercel doesn't cache the result of this route,
@@ -8,7 +9,7 @@ export const revalidate = 0;
 export async function GET(request) {
   const client = new Ably.Rest(process.env.ABLY_API_KEY);
   const tokenRequestData = await client.auth.createTokenRequest({
-    clientId: 'ably-nextjs-demo',
+    clientId: crypto.randomUUID(),
   });
   console.log(`Request: ${JSON.stringify(tokenRequestData)}`);
   return Response.json(tokenRequestData);

--- a/app/api/route.js
+++ b/app/api/route.js
@@ -1,5 +1,8 @@
 import Ably from 'ably';
 
+// ensure Vercel doesn't cache the result of this route,
+// as otherwise the token request data will eventually become outdated
+// and we won't be able to authenticate on client side
 export const revalidate = 0;
 
 export async function GET(request) {

--- a/components/Chat.jsx
+++ b/components/Chat.jsx
@@ -13,7 +13,18 @@ export default function Chat() {
 
   useEffect(() => {
     const clientId = `ably-chat-demo-user-${Math.random().toString(36).substring(2, 10)}`;
-    const realtimeClient = new Ably.Realtime({ authUrl: `/api?clientId=${clientId}`, clientId });
+    const realtimeClient = new Ably.Realtime({
+      authCallback: async (tokenParams, callback) => {
+        try {
+          const response = await fetch(`/api?clientId=${clientId}`);
+          const token = await response.text();
+          callback(null, token);
+        } catch (error) {
+          callback(error, null);
+        }
+      },
+      clientId,
+    });
     const client = new ChatClient(realtimeClient);
     setChatClient(client);
     return () => {

--- a/components/Chat.jsx
+++ b/components/Chat.jsx
@@ -12,7 +12,8 @@ export default function Chat() {
   const [chatClient, setChatClient] = useState(null);
 
   useEffect(() => {
-    const realtimeClient = new Ably.Realtime({ authUrl: '/api' });
+    const clientId = `ably-chat-demo-user-${Math.random().toString(36).substring(2, 10)}`;
+    const realtimeClient = new Ably.Realtime({ authUrl: `/api?clientId=${clientId}`, clientId });
     const client = new ChatClient(realtimeClient);
     setChatClient(client);
     return () => {

--- a/components/ChatBox.jsx
+++ b/components/ChatBox.jsx
@@ -3,8 +3,7 @@ import { useChatClient, useMessages } from '@ably/chat/react';
 import styles from './ChatBox.module.css';
 
 export default function ChatBox() {
-  const chatClient = useChatClient();
-  const currentClientId = chatClient.clientId;
+  const { clientId: currentClientId } = useChatClient();
   const inputBox = useRef(null);
   const messageEndRef = useRef(null);
 

--- a/components/ChatBox.jsx
+++ b/components/ChatBox.jsx
@@ -1,8 +1,10 @@
 import React, { useEffect, useState, useRef } from 'react';
-import { useMessages } from '@ably/chat/react';
+import { useChatClient, useMessages } from '@ably/chat/react';
 import styles from './ChatBox.module.css';
 
 export default function ChatBox() {
+  const chatClient = useChatClient();
+  const currentClientId = chatClient.clientId;
   const inputBox = useRef(null);
   const messageEndRef = useRef(null);
 
@@ -50,8 +52,9 @@ export default function ChatBox() {
 
   const messageElements = messages.map((message, index) => {
     const key = message.serial ?? index;
+    const isSentByMe = message.clientId === currentClientId;
     return (
-      <span key={key} className={styles.message}>
+      <span key={key} className={isSentByMe ? styles.sentMessage : styles.message}>
         {message.text}
       </span>
     );

--- a/components/ChatBox.module.css
+++ b/components/ChatBox.module.css
@@ -62,3 +62,13 @@
   flex-grow: 0;
   border-bottom-left-radius: 0;
 }
+
+.sentMessage {
+  background-color: #005c97;
+  color: white;
+  padding: 1em;
+  border-radius: 10px;
+  flex-grow: 0;
+  border-bottom-right-radius: 0;
+  align-self: flex-end;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@ably/chat": "^1.3.1",
         "ably": "^2.21.0",
+        "jsonwebtoken": "^9.0.3",
         "next": "^14.2.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -18,6 +19,9 @@
         "eslint": "8.57.0",
         "eslint-config-next": "^13.4.19",
         "prettier": "^3.2.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@ably/chat": {
@@ -967,6 +971,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -1303,6 +1313,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/emoji-regex": {
@@ -2863,6 +2882,28 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -2876,6 +2917,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -2938,11 +3000,53 @@
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -3019,8 +3123,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -3681,6 +3784,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safe-regex-test": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.3.tgz",
@@ -3710,7 +3833,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
       "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@ably/chat": "^1.3.1",
     "ably": "^2.21.0",
+    "jsonwebtoken": "^9.0.3",
     "next": "^14.2.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"


### PR DESCRIPTION
## Summary

- Replaced hardcoded `clientId: 'ably-nextjs-demo'` in the token endpoint with a randomly generated ID per browser session so each tab gets a unique Ably identity
- Update authentication code to use recommended JWT approach
- Added sent vs received message styling in ChatBox: your messages appear right-aligned in blue, others' appear left-aligned in grey

Builds on #15. See `BUG-BRIEFING.md` for the full diagnosis.

## Test plan

- [ ] Open `http://localhost:3000` in two browser tabs
- [ ] Send a message from each tab
- [ ] Confirm your own messages appear right-aligned (blue) and the other tab's messages appear left-aligned (grey)
- [ ] Confirm message history loads correctly on page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)